### PR TITLE
Fix ad component breaking map

### DIFF
--- a/src/components/Ad.tsx
+++ b/src/components/Ad.tsx
@@ -1,21 +1,36 @@
 'use client'
 
-import React from 'react'
-
-import { Adsense } from '@ctrl/react-adsense'
+import React, { useEffect, useRef } from 'react'
 
 export const AdBlock = () => {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    try {
+      // the global script is loaded in the document head. pushing a new
+      // request will render the ad without using document.write
+      if (typeof window !== 'undefined') {
+        ;(window as any).adsbygoogle = (window as any).adsbygoogle || []
+        ;(window as any).adsbygoogle.push({})
+      }
+    } catch (e) {
+      // ignore ad rendering errors
+      console.error('adsbygoogle error', e)
+    }
+  }, [])
+
   return (
     <ErrorBoundary>
-      <div className="my-6 w-full">
-        <Adsense
-          layout="in-article"
-          client="ca-pub-7420123397062174"
-          slot="6989466712"
-          format="fluid"
-          responsive="true"
+      <div className="my-6 w-full" ref={ref as React.RefObject<HTMLDivElement>}>
+        <ins
+          className="adsbygoogle"
           style={{ display: 'block' }}
-        ></Adsense>
+          data-ad-client="ca-pub-7420123397062174"
+          data-ad-slot="6989466712"
+          data-ad-format="fluid"
+          data-ad-layout="in-article"
+          data-full-width-responsive="true"
+        />
       </div>
     </ErrorBoundary>
   )


### PR DESCRIPTION
## Summary
- reimplement AdBlock without `@ctrl/react-adsense`
- call `adsbygoogle.push` directly so the map element isn't replaced when ads load

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685aa6b1a4d0832fa5db423c45f3f14c