### PR TITLE
Avoid map blanking when ads blocked

### DIFF
--- a/src/components/Ad.tsx
+++ b/src/components/Ad.tsx
@@ -1,23 +1,33 @@
 'use client'
 
 import React, { useEffect, useRef } from 'react'
+import useAdBlocker from '@/hooks/useAdBlocker'
 
 export const AdBlock = () => {
   const ref = useRef<HTMLDivElement | null>(null)
+  const adBlocked = useAdBlocker()
 
   useEffect(() => {
+    if (adBlocked) return
+
     try {
       // the global script is loaded in the document head. pushing a new
       // request will render the ad without using document.write
       if (typeof window !== 'undefined') {
-        ;(window as any).adsbygoogle = (window as any).adsbygoogle || []
-        ;(window as any).adsbygoogle.push({})
+        const ads = (window as any).adsbygoogle
+        if (ads && typeof ads.push === 'function') {
+          ads.push({})
+        }
       }
     } catch (e) {
       // ignore ad rendering errors
       console.error('adsbygoogle error', e)
     }
-  }, [])
+  }, [adBlocked])
+
+  if (adBlocked) {
+    return null
+  }
 
   return (
     <ErrorBoundary>

--- a/src/hooks/useAdBlocker.ts
+++ b/src/hooks/useAdBlocker.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+const useAdBlocker = () => {
+  const [adBlocked, setAdBlocked] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const tester = document.createElement('div')
+    tester.className = 'adsbox'
+    tester.style.position = 'absolute'
+    tester.style.height = '1px'
+    tester.style.width = '1px'
+    tester.style.pointerEvents = 'none'
+    tester.style.opacity = '0'
+    document.body.appendChild(tester)
+    setAdBlocked(tester.offsetHeight === 0)
+    document.body.removeChild(tester)
+  }, [])
+
+  return adBlocked
+}
+
+export default useAdBlocker


### PR DESCRIPTION
## Summary
- detect ad blockers with a small hook
- skip rendering ad blocks when an ad blocker is present
- guard ad rendering logic against missing script

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d428b7258832f98d1769645016450