### PR TITLE
Rename station 'Mohrenstraße' to 'Anton-Wilhelm-Amo-Straße'

### DIFF
--- a/src/app/(game)/berlin/data/features.json
+++ b/src/app/(game)/berlin/data/features.json
@@ -4184,7 +4184,7 @@
     {
       "type": "Feature",
       "geometry": { "type": "Point", "coordinates": [13.383798, 52.511519] },
-      "properties": { "id": 324, "name": "Mohrenstraße", "line": "U2" },
+      "properties": { "id": 324, "name": "Anton-Wilhelm-Amo-Straße", "line": "U2" },
       "id": 324
     },
     {


### PR DESCRIPTION
The station was renamed "Anton-Wilhelm-Amo-Straße" on December 14 2025 following the renaming of the street from which it takes its name.