### PR TITLE
London: Undergroundoku callout + harden homepage build

### DIFF
--- a/src/app/(game)/london/page.tsx
+++ b/src/app/(game)/london/page.tsx
@@ -26,7 +26,21 @@ export default function London() {
   return (
     <Provider value={config}>
       <Main className={`${font.className} min-h-screen`}>
-        <GamePage fc={fc} />
+        <GamePage
+          fc={fc}
+          callout={
+            <a
+              href="https://undergroundoku.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 block rounded-lg bg-amber-50 p-4 text-sm text-amber-900 shadow-sm transition hover:bg-amber-100"
+            >
+              Tube fan? Try{' '}
+              <span className="font-bold underline">Undergroundoku</span>, a
+              daily puzzle game.
+            </a>
+          }
+        />
       </Main>
     </Provider>
   )

--- a/src/components/GamePage.tsx
+++ b/src/components/GamePage.tsx
@@ -27,9 +27,11 @@ import { bbox } from '@turf/turf'
 export default function GamePage({
   fc,
   routes,
+  callout,
 }: {
   fc: DataFeatureCollection
   routes?: RoutesFeatureCollection
+  callout?: React.ReactNode
 }) {
   const { BEG_THRESHOLD, CITY_NAME, MAP_CONFIG, LINES, MAP_FROM_DATA } =
     useConfig()
@@ -483,6 +485,7 @@ export default function GamePage({
           minimizable
           defaultMinimized
         />
+        {callout}
         <hr className="my-4 w-full border-b border-zinc-100" />
         <FoundList
           found={found}

--- a/src/components/LinkPreview.tsx
+++ b/src/components/LinkPreview.tsx
@@ -2,18 +2,29 @@
 import jsdom from 'jsdom'
 
 async function LinkPreview({ url }: { url: string }) {
-  const response = await fetch(url)
-  const data = await response.text()
-  const doc = new jsdom.JSDOM(data)
-  const title = doc.window.document.querySelector('title')?.textContent || ''
-  const description =
-    doc.window.document
-      .querySelector('meta[name="description"]')
-      ?.getAttribute('content') || ''
-  const image =
-    doc.window.document
-      .querySelector('meta[property="og:image"]')
-      ?.getAttribute('content') || ''
+  let title = ''
+  let description = ''
+  let image = ''
+
+  try {
+    const response = await fetch(url)
+    const data = await response.text()
+    const doc = new jsdom.JSDOM(data)
+    title = doc.window.document.querySelector('title')?.textContent || ''
+    description =
+      doc.window.document
+        .querySelector('meta[name="description"]')
+        ?.getAttribute('content') || ''
+    image =
+      doc.window.document
+        .querySelector('meta[property="og:image"]')
+        ?.getAttribute('content') || ''
+  } catch (err) {
+    // External sites can be unreachable or unparseable at build time; skip the
+    // preview rather than failing the whole static export.
+    console.error(`LinkPreview failed for ${url}`, err)
+    return null
+  }
 
   return (
     <a

--- a/src/components/Tweet.tsx
+++ b/src/components/Tweet.tsx
@@ -2,10 +2,9 @@ import { Suspense } from 'react'
 import { getTweet } from 'react-tweet/api'
 import { type TweetProps, TweetNotFound, TweetSkeleton } from 'react-tweet'
 
-import type { Tweet as TweetType } from 'react-tweet/api'
-
 import {
   type TwitterComponents,
+  type EnrichedTweet,
   TweetHeader,
   TweetInReplyTo,
   TweetBody,
@@ -14,12 +13,11 @@ import {
 } from 'react-tweet'
 
 type Props = {
-  tweet: TweetType
+  tweet: EnrichedTweet
   components?: TwitterComponents
 }
 
-export const MyTweet = ({ tweet: t, components }: Props) => {
-  const tweet = enrichTweet(t)
+export const MyTweet = ({ tweet, components }: Props) => {
   return (
     <figure className="mb-4 break-inside-avoid rounded-2xl border px-4 py-6">
       <TweetHeader tweet={tweet} components={components} />
@@ -32,22 +30,29 @@ export const MyTweet = ({ tweet: t, components }: Props) => {
 }
 
 const TweetContent = async ({ id, components, onError }: TweetProps) => {
-  const tweet = id
-    ? await getTweet(id).catch((err) => {
-        if (onError) {
-          onError(err)
-        } else {
-          console.error(err)
-        }
-      })
-    : undefined
+  let enriched: EnrichedTweet | undefined
 
-  if (!tweet) {
+  try {
+    const tweet = id ? await getTweet(id) : undefined
+    // enrichTweet can throw on malformed/partial API responses (e.g. when the
+    // tweet endpoint is rate-limited at build time), so keep it inside the try.
+    if (tweet) {
+      enriched = enrichTweet(tweet)
+    }
+  } catch (err) {
+    if (onError) {
+      onError(err)
+    } else {
+      console.error(err)
+    }
+  }
+
+  if (!enriched) {
     const NotFound = components?.TweetNotFound || TweetNotFound
     return <NotFound />
   }
 
-  return <MyTweet tweet={tweet} components={components} />
+  return <MyTweet tweet={enriched} components={components} />
 }
 
 export const Tweet = ({


### PR DESCRIPTION
## Summary
- Add a callout on the **London** page linking to [undergroundoku.com](https://undergroundoku.com), placed in the side panel between the lines-completion summary and the found-stations list: _"Tube fan? Try Undergroundoku, a daily puzzle game."_
- Implemented via an optional `callout` slot on the shared `GamePage`, passed only from the London page — other cities are unaffected.

## Build hardening (unrelated pre-existing flakiness)
The cache-less Vercel build was failing while statically prerendering the homepage (`/`) with `TypeError: r is not iterable`, because it fetches tweets and link previews from external sites at build time. Made both fail-safe:
- `Tweet.tsx`: moved `enrichTweet()` inside the try/catch (the actual thrower on malformed/rate-limited tweet API responses); falls back to `TweetNotFound`.
- `LinkPreview.tsx`: wrapped fetch + jsdom parse in try/catch; returns `null` (preview skipped) on failure instead of crashing the export.

## Verification
- `npm run build` → exit 0, no prerender errors
- `npm run lint` → clean