### PR TITLE
Bound homepage build-time fetches so a hung request can't time out page generation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,8 +3,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx'],
-  // page generation timeout
-  staticPageGenerationTimeout: 30,
+  // The homepage makes 14 external requests (tweets + link previews) while being
+  // prerendered. Each is capped at 5s, so leave headroom for the worst case where
+  // every one of them times out rather than failing the build.
+  staticPageGenerationTimeout: 120,
 }
 
 

--- a/src/components/LinkPreview.tsx
+++ b/src/components/LinkPreview.tsx
@@ -1,13 +1,19 @@
 /* eslint-disable @next/next/no-img-element */
 import jsdom from 'jsdom'
 
+// See the note in Tweet.tsx: these run at build time against the page's
+// generation budget, so every request needs an explicit ceiling.
+const FETCH_TIMEOUT_MS = 5_000
+
 async function LinkPreview({ url }: { url: string }) {
   let title = ''
   let description = ''
   let image = ''
 
   try {
-    const response = await fetch(url)
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
     const data = await response.text()
     const doc = new jsdom.JSDOM(data)
     title = doc.window.document.querySelector('title')?.textContent || ''

--- a/src/components/Tweet.tsx
+++ b/src/components/Tweet.tsx
@@ -29,11 +29,19 @@ export const MyTweet = ({ tweet, components }: Props) => {
   )
 }
 
+// The homepage is statically prerendered, so this fetch runs during `next build`
+// against the page's `staticPageGenerationTimeout` budget. A hung request is not
+// a rejected promise, so the try/catch below can't save us — bound it explicitly
+// and degrade to TweetNotFound instead of timing out the whole page.
+const FETCH_TIMEOUT_MS = 5_000
+
 const TweetContent = async ({ id, components, onError }: TweetProps) => {
   let enriched: EnrichedTweet | undefined
 
   try {
-    const tweet = id ? await getTweet(id) : undefined
+    const tweet = id
+      ? await getTweet(id, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
+      : undefined
     // enrichTweet can throw on malformed/partial API responses (e.g. when the
     // tweet endpoint is rate-limited at build time), so keep it inside the try.
     if (tweet) {


### PR DESCRIPTION
## Problem

The homepage (`src/app/(website)/page.tsx`) is statically prerendered — it shows as `○ /` in the build output. That means all of its external requests run during `next build`, against the page's `staticPageGenerationTimeout` budget:

- `<Tweets />` → 7 fetches to Twitter's syndication API
- `<LinkPreviews />` → 7 fetches of full third-party news pages, each then parsed through jsdom

That's 14 blocking round-trips for one page, and none of them had a timeout. `staticPageGenerationTimeout` was set to 30s.

The previous hardening pass (4c787c7) wrapped these calls in `try`/`catch`, but that can't help here: **a stalled socket is not a rejected promise.** When a request hangs, nothing is thrown for the `catch` to intercept — the page generation budget simply runs out and the build dies. One slow or throttled connection to any of the 14 endpoints takes down the whole build, which is why the failure was intermittent and environment-dependent, and why it reproduced identically on both `main` and a feature branch.

## Fix

Bound each external request at 5s with `AbortSignal.timeout`. This converts a hang into a `TimeoutError`, which the existing `try`/`catch` blocks already handle — so a slow tweet degrades to `TweetNotFound` and a slow preview is skipped, instead of failing the build.

`getTweet` forwards its second argument straight to `fetch` (`react-tweet/dist/api/get-tweet.js:41`), so the signal applies cleanly. The signal also covers the response body read, so a slow `.text()` on a large news page can't hang either.

`staticPageGenerationTimeout` goes 30s → 120s. With every request capped at 5s, the absolute worst case is 14 × 5s = 70s of timeouts, which now fits inside the budget — so the page renders with placeholders rather than killing the build.

## Verification

- Clean `next build` from scratch passes, exit 0, no type errors.
- Homepage stays at 19.4 kB, confirming tweets and previews still render for real rather than silently falling back to placeholders.
- Timeout path confirmed directly: a fetch to a blackholed host rejects with `TimeoutError` at the bound rather than hanging.

## Note

This makes the build resilient to slow external services, but the homepage still *depends* on Twitter and seven news sites being reachable at build time — when they're down, the content silently disappears from the page. Caching those payloads in the repo would remove the coupling entirely. Out of scope here.
