### PR TITLE
london: restore Elizabeth line station Iver

### DIFF
--- a/src/app/(game)/london/data/features.json
+++ b/src/app/(game)/london/data/features.json
@@ -4018,6 +4018,23 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
+          -0.5063703708080247,
+          51.50862307536082
+        ]
+      },
+      "properties": {
+        "id": 1,
+        "name": "Iver",
+        "line": "ElizabethLine",
+        "order": 181
+      },
+      "id": 1
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
           -0.409299,
           51.600495
         ]
@@ -9931,14 +9948,14 @@
     }
   ],
   "properties": {
-    "totalStations": 584,
+    "totalStations": 585,
     "stationsPerLine": {
       "Bakerloo": 25,
       "Central": 49,
       "Circle": 35,
       "DLR": 45,
       "District": 60,
-      "ElizabethLine": 40,
+      "ElizabethLine": 41,
       "HammersmithAndCity": 29,
       "Jubilee": 27,
       "Metropolitan": 34,

--- a/src/app/(game)/london/data/source.json
+++ b/src/app/(game)/london/data/source.json
@@ -6189,6 +6189,10 @@
               "path_index": 178
             },
             {
+              "id": "Iver",
+              "path_index": 181
+            },
+            {
               "id": "Langley",
               "path_index": 183
             },
@@ -27990,6 +27994,29 @@
         "level": 0,
         "station_id": "Langley",
         "summary": "Langley: Station Open"
+      }
+    },
+    "Iver": {
+      "live_code": "Iver",
+      "routes": ["ElizabethLine", "NationalRailGW"],
+      "brands": ["NationalRail", "TfLRail"],
+      "name": "Iver",
+      "coords": [51.50862307536082, -0.5063703708080247],
+      "route_icon_names": [
+        "uk-london-crossrail",
+        "uk-rail-great-western-railway"
+      ],
+      "status": {
+        "description": "",
+        "effect_time_periods": [
+          {
+            "end": "2023-10-10T08:43:57.048206+00:00",
+            "start": "2023-10-10T06:43:57.048206+00:00"
+          }
+        ],
+        "level": 0,
+        "station_id": "Iver",
+        "summary": "Iver: Station Open"
       }
     },
     "ElephantAndCastle": {


### PR DESCRIPTION
## What

Restores the Elizabeth line station **Iver**, which disappeared from the London game.

## Why it vanished

`features.json` (what the game renders) is generated from `source.json` by `london/data/preprocess.ts`. A station only survives regeneration if it's a `stop_point` in a route pattern **and** has a `stops` entry in `source.json`.

Iver was only ever *hand-added to `features.json`* (in 2023) and never existed in `source.json`. Commit `66e1001` ("Adding new London Overground line names") introduced `preprocess.ts` and regenerated `features.json` from `source.json`, so Iver was silently dropped. It was the only genuine casualty of that regen — the other removals there were Overground stations being reclassified into the new named lines.

## The fix (durable)

- **`source.json`**: add an `Iver` `stops` entry and insert it as a `stop_point` in the Abbey Wood · Reading pattern, between **West Drayton** and **Langley** (`path_index` 181) — its correct real-world position. Now it survives future regenerations.
- **`features.json`**: regenerated via `bun preprocess.ts`; Iver added (Elizabeth line 40 → 41, total 584 → 585), all existing station IDs preserved.

## Notes

- `routes.json` was intentionally left untouched: `preprocess.ts` rewrites it without the extra overlap-offset fields (`segmentName`, `overlapSectionId`, `overlapOffsetPx`, …) that the committed version carries from a further post-processing step. The stop_point edit doesn't change path geometry, so the committed `routes.json` stays correct. That preprocess/routes.json mismatch is a pre-existing gap worth addressing separately.